### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests
 requests_cache
+python-dateutil==2.7.3


### PR DESCRIPTION
I needed to add python-dateutil in order for this library to work in python 3.6